### PR TITLE
bug: 'select *' and 'group by' can't be used in same time

### DIFF
--- a/src/sql/plan/planner.rs
+++ b/src/sql/plan/planner.rs
@@ -149,6 +149,9 @@ impl<'a, C: Catalog> Planner<'a, C> {
 
                 // Build SELECT clause.
                 let mut hidden = 0;
+                if select.is_empty() && ! group_by.is_empty() {
+                    return Err(Error::Value("Wrong use of 'select *' and 'group_by' ".into()));
+                }
                 if !select.is_empty() {
                     // Inject hidden SELECT columns for fields and aggregates used in ORDER BY and
                     // HAVING expressions but not present in existing SELECT output. These will be


### PR DESCRIPTION
select * from table;
select * from table group by field;
These query sql will get same result.Because the second sql been misidentified as "select * from table".
