### PR TITLE
MVCC: using first() to get the range start

### DIFF
--- a/src/storage/mvcc.rs
+++ b/src/storage/mvcc.rs
@@ -537,7 +537,7 @@ impl<E: Engine> Transaction<E> {
         // the same invariant.
         let from = Key::Version(
             key.into(),
-            self.state.active.iter().min().copied().unwrap_or(self.state.version + 1),
+            self.state.active.first().copied().unwrap_or(self.state.version + 1),
         )
         .encode();
         let to = Key::Version(key.into(), u64::MAX).encode();


### PR DESCRIPTION
As the active state is a btree set, the elements are sorted; using first() gives us:
* better semantic meaning
* better performance （O(n) -> O(1))